### PR TITLE
adding default values for 'avePS' in badTriggers

### DIFF
--- a/ShiftMonitorNCR.py
+++ b/ShiftMonitorNCR.py
@@ -836,10 +836,10 @@ class ShiftMonitor:
                 self.recordAllBadRates[trigger] += 1
                 # Record consecutive bad rates
                 if not self.badRates.has_key(trigger):
-                    self.badRates[trigger] = [ 1, True, properAvePSRate, -999, -999 ]
+                    self.badRates[trigger] = [ 1, True, properAvePSRate, -999, -999, -999 ]
                 else:
                     last = self.badRates[trigger]
-                    self.badRates[trigger] = [ last[0]+1, True, properAvePSRate, -999, -999 ]
+                    self.badRates[trigger] = [ last[0]+1, True, properAvePSRate, -999, -999, -999 ]
             else:
                 self.normal += 1
                 # Remove warning from badRates


### PR DESCRIPTION
If we do not want to make a prediction "doPred==False", the default value of the badTrigger[trigger] is to short, so when asking for the 6th element, the program will crash.
