### PR TITLE
update setup and fix a cfrash

### DIFF
--- a/ShiftMonitorNCR.py
+++ b/ShiftMonitorNCR.py
@@ -1013,7 +1013,10 @@ L1_ETMHF110_HTT60er:   {L1_ETMHF110_HTT60er} kHz
         live_l1_rate = self.parser.getL1APhysics(self.runNumber, self.lastLS, self.currentLS)
         dead_l1_rate = self.parser.getL1APhysicsLost(self.runNumber, self.lastLS, self.currentLS)
         rates = {}
-        rates['total'] = live_l1_rate[latestLS] + dead_l1_rate[latestLS]
+        try:
+          rates['total'] = live_l1_rate[latestLS] + dead_l1_rate[latestLS]
+        except:
+          rates['total'] = 0.
         for trigger in self.Rates:
           try:
             #print latestLS, self.currentLS, trigger, self.Rates[trigger][latestLS]

--- a/set.sh
+++ b/set.sh
@@ -2,18 +2,26 @@
 
 HOST=$(hostname)
 
-if [[ $HOST == *"lxplus"* ]]; then
-    cd /afs/cern.ch/cms/slc6_amd64_gcc493/cms/cmssw/CMSSW_7_6_3/src
+if [[ $HOST == *lxplus* ]]; then
+    # lxplus machines
+    export VO_CMS_SW_DIR=/nfshome0/cmssw3
+    export SCRAM_ARCH=slc7_amd64_gcc630
+    export CMSSW_VERSION=CMSSW_9_2_10
+elif [[ $HOST == *hilton* ]]; then
+    # hilton machines
+    export VO_CMS_SW_DIR=/opt/offline
+    export SCRAM_ARCH=slc7_amd64_gcc630
+    export CMSSW_VERSION=CMSSW_9_2_10
 else
-    export SCRAM_ARCH=slc5_amd64_gcc462
-    export VO_CMS_SW_DIR=/nfshome0/cmssw2
-    source $VO_CMS_SW_DIR/cmsset_default.sh
-    cd $VO_CMS_SW_DIR/$SCRAM_ARCH/cms/cmssw/CMSSW_5_2_6/src
+    # other online machines
+    export VO_CMS_SW_DIR=/nfshome0/cmssw3
+    export SCRAM_ARCH=slc6_amd64_gcc493
+    export CMSSW_VERSION=CMSSW_8_0_22
 fi
 
-#cmsenv
+source $VO_CMS_SW_DIR/cmsset_default.sh
+cd $VO_CMS_SW_DIR/$SCRAM_ARCH/cms/cmssw/$CMSSW_VERSION/
 eval `scramv1 runtime -sh`
-
 cd -
 
 alias rateMon='python ShiftMonitorTool.py'


### PR DESCRIPTION
  - update the set.sh script to use SLC6 or SLC7 releases
  - fix a crash when total L1 rate is not available for the latest LS 