### PR TITLE
add monitor for hcal laser misfires

### DIFF
--- a/ShiftMonitorNCR.py
+++ b/ShiftMonitorNCR.py
@@ -238,6 +238,19 @@ L1_ETMHF120_HTT60er:   {L1_ETMHF120_HTT60er:.1f} kHz
           period    = 600., # s
           actions   = [EmailMessage, AudioMessage, OnScreenMessage] )
 
+        # set upper threshold for the L1 bit that monitor Laser Misfires for HCAL
+        l1_hcalLaserMisfires_rate_alert = RateAlert(
+          message   = 'high rate of HCAL laser misfire'
+          details   = '''
+Plase check the rate of L1_HCAL_LaserMon_Veto and contact the HCAL DoC
+''',
+          level     = AlertLevel.WARNING,
+          measure   = lambda rates: rates['L1_HCAL_LaserMon_Veto'] / 1000.,     # thresholds are in Hz
+          threshold =  10., #kHz
+          period    = 600., #s
+          actions   = [EmailMessage, AudioMessage, OnScreenMessage] )
+        
+
         l1_met_rate_alert = PriorityAlert(l1_centralmet_rate_alert, l1_formwardmet_rate_alert)
 
         self.l1t_rate_alert = MultipleAlert(
@@ -245,7 +258,8 @@ L1_ETMHF120_HTT60er:   {L1_ETMHF120_HTT60er:.1f} kHz
           l1_singlemu_rate_alert,
           l1_singleeg_rate_alert,
           l1_singlejet_rate_alert,
-          l1_met_rate_alert )
+          l1_met_rate_alert,
+          l1_hcalLaserMisfires_rate_alert)
 
         # Other options
         self.quiet = False              # Prints fewer messages in this mode


### PR DESCRIPTION
this change is supposed to set an upper threshold on the `L1_HCAL_LaserMon_Veto` bit that monitors the rate of laser misfires for HCAL.

the values are tuned based on what I could see for run [313792](https://cmswbm2.cern.ch/cmsdb/servlet/ChartL1TriggerRates?fromTime=&toTime=&fromLSNumber=&toLSNumber=&minRate=&maxRate=&minCount=&maxCount=&beforePrescale=1&drawCounts=0&drawLumisec=1&runID=313792&bitID=511&type=0&TRIGGER_NAME=L1_HCAL_LaserMon_Veto&LSLength=23.31040958)

I'm not sure how to test the change though. @geoff-smith
@jkunkle